### PR TITLE
Add '::boost::' namespace specifier to ssl_delegate.ipp

### DIFF
--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -33,7 +33,7 @@ void boost::network::http::impl::ssl_delegate::connect(
   socket_.reset(new asio::ssl::stream<asio::ip::tcp::socket>(service_, *context_));
   socket_->lowest_layer().async_connect(
       endpoint,
-      bind(&boost::network::http::impl::ssl_delegate::handle_connected,
+      ::boost::bind(&boost::network::http::impl::ssl_delegate::handle_connected,
            boost::network::http::impl::ssl_delegate::shared_from_this(),
            asio::placeholders::error,
            handler));


### PR DESCRIPTION
For fixing up a compile error(C2668) at Visual C++ 2010.
