### PR TITLE
Add missing include of vector to request_base

### DIFF
--- a/http/src/network/protocol/http/request/request_base.ipp
+++ b/http/src/network/protocol/http/request/request_base.ipp
@@ -10,6 +10,7 @@
 #include <network/protocol/http/request/request_base.hpp>
 #include <thread>
 #include <cstring>
+#include <vector>
 
 namespace network { namespace http {
 


### PR DESCRIPTION
This fixes the build with `CPP-NETLIB_BUILD_TESTS` and `CPP-NETLIB_BUILD_EXAMPLES` set to `OFF`.
