### PR TITLE
fixed async client multithread problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,12 +86,12 @@ If you want to run the tests that come with cpp-netlib, there are a few things
 you will need. These are:
 
   * A compiler (GCC 4.x, Clang 2.8, MSVC 2008)
-  * A build tool (CMake [#]_ recommended, Boost.Build also an option)
+  * A build tool (CMake_ recommended, Boost.Build also an option)
   * OpenSSL headers (optional)
 
 .. note:: This assumes that you have cpp-netlib at the top-level of
           your home directory.
-  [#] http://www.cmake.org/
+.. _CMake: https://cmake.org/
 
 Hacking on cpp-netlib
 ---------------------

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(${CPP-NETLIB_SOURCE_DIR})
 
 file(GLOB_RECURSE CPP-NETLIB_HEADERS
     "${CPP-NETLIB_SOURCE_DIR}/boost/" "*.hpp")
-
+set(CMAKE_CXX_FLAGS "/DBOOST_SPIRIT_THREADSAFE")
 set(CPP-NETLIB_URI_SRCS uri/uri.cpp uri/schemes.cpp)
 add_library(cppnetlib-uri ${CPP-NETLIB_URI_SRCS})
 set_target_properties(cppnetlib-uri


### PR DESCRIPTION
async client crashes in multithread condition, because
the boost::spirit grammar object is not thread safe without /DBOOST_SPIRIT_THREADSAFE  

the detailed discussion can be seen below:
https://groups.google.com/forum/#!topic/cpp-netlib/yqa5Qtpc1j4