### PR TITLE
Asio standalone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 
     # Asio
-    add_definitions(-DASIO_HEADER_ONLY)
+    add_definitions(-DASIO_STANDALONE)
     include_directories(deps/asio/asio/include)
 
     enable_testing()

--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -508,7 +508,7 @@ struct http_async_connection
   }
 
   int timeout_;
-  ::asio::deadline_timer timer_;
+  ::asio::steady_timer timer_;
   bool is_timedout_;
   bool follow_redirect_;
   resolver_type& resolver_;

--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -12,7 +12,7 @@
 #include <iterator>
 #include <cstdint>
 #include <boost/algorithm/string/trim.hpp>
-#include <asio/deadline_timer.hpp>
+#include <asio/steady_timer.hpp>
 #include <asio/placeholders.hpp>
 #include <asio/strand.hpp>
 #include <asio/streambuf.hpp>
@@ -109,7 +109,7 @@ struct http_async_connection
                                                           callback, generator, ec, endpoint_range);
                                   }));
     if (timeout_ > 0) {
-      timer_.expires_from_now(boost::posix_time::seconds(timeout_));
+      timer_.expires_from_now(std::chrono::seconds(timeout_));
       timer_.async_wait(request_strand_.wrap([=] (std::error_code const &ec) {
             self->handle_timeout(ec);
           }));

--- a/boost/network/protocol/http/client/connection/sync_normal.hpp
+++ b/boost/network/protocol/http/client/connection/sync_normal.hpp
@@ -10,7 +10,7 @@
 
 #include <iterator>
 #include <functional>
-#include <asio/deadline_timer.hpp>
+#include <asio/steady_timer.hpp>
 #include <asio/streambuf.hpp>
 #include <boost/network/protocol/http/algorithms/linearize.hpp>
 #include <boost/network/protocol/http/response.hpp>
@@ -132,7 +132,7 @@ struct http_sync_connection
   }
 
   int timeout_;
-  ::asio::deadline_timer timer_;
+  ::asio::steady_timer timer_;
   resolver_type& resolver_;
   resolver_function_type resolve_;
   ::asio::ip::tcp::socket socket_;

--- a/boost/network/protocol/http/client/connection/sync_normal.hpp
+++ b/boost/network/protocol/http/client/connection/sync_normal.hpp
@@ -77,7 +77,7 @@ struct http_sync_connection
       }
     }
     if (timeout_ > 0) {
-      timer_.expires_from_now(boost::posix_time::seconds(timeout_));
+      timer_.expires_from_now(std::chrono::seconds(timeout_));
       auto self = this->shared_from_this();
       timer_.async_wait([=] (std::error_code const &ec) {
           self->handle_timeout(ec);

--- a/boost/network/protocol/http/client/connection/sync_ssl.hpp
+++ b/boost/network/protocol/http/client/connection/sync_ssl.hpp
@@ -119,7 +119,7 @@ struct https_sync_connection
       }
     }
     if (timeout_ > 0) {
-      timer_.expires_from_now(boost::posix_time::seconds(timeout_));
+      timer_.expires_from_now(std::chrono::seconds(timeout_));
       auto self = this->shared_from_this();
       timer_.async_wait(
           [=](std::error_code const& ec) { self->handle_timeout(ec); });
@@ -173,7 +173,7 @@ struct https_sync_connection
   }
 
   int timeout_;
-  ::asio::deadline_timer timer_;
+  ::asio::steady_timer timer_;
   resolver_type& resolver_;
   resolver_function_type resolve_;
   ::asio::ssl::context context_;


### PR DESCRIPTION
According to [Asio documentation](http://think-async.com/Asio/AsioStandalone) to use without a dependency on Boost header files or libraries `ASIO_STANDALONE` should be defined.

Also, as soon Boost `date_time` library is not available, cpp-netlib should not use `deadline_timer` and `boost::posix_time` .

Kind Regards,
Andrey