### PR TITLE
Fix linker errors

### DIFF
--- a/libs/network/test/uri/CMakeLists.txt
+++ b/libs/network/test/uri/CMakeLists.txt
@@ -18,7 +18,7 @@ if (Boost_FOUND)
         add_dependencies(cpp-netlib-${test} cppnetlib-uri gtest_main)
         target_link_libraries(cpp-netlib-${test}
             ${CMAKE_THREAD_LIBS_INIT} cppnetlib-uri
-	    gtest_main)
+	    gtest_main ${Boost_LIBRARIES})
         if (OPENSSL_FOUND)
           target_link_libraries(cpp-netlib-${test} ${OPENSSL_LIBRARIES})
         endif()


### PR DESCRIPTION
Since the code was refactored to use Boost.Asio, the tests need to link to Boost.Asio.