### PR TITLE
Fix chunk and content-length encoding

### DIFF
--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -361,13 +361,12 @@ struct http_async_protocol_handler {
     for (typename string_type::const_iterator iter =
              std::search(begin, partial_parsed.end(), crlf.begin(), crlf.end());
          iter != partial_parsed.end();
-         iter =
-             std::search(begin, partial_parsed.end(), crlf.begin(), crlf.end())) {
+         iter = std::search(begin, partial_parsed.end(), crlf.begin(), crlf.end())) {
       string_type line(begin, iter);
       if (line.empty()) {
-          std::advance(iter, 2);
-          begin = iter;
-          continue;
+        std::advance(iter, 2);
+        begin = iter;
+        continue;
       }
       std::stringstream stream(line);
       int len;
@@ -375,8 +374,10 @@ struct http_async_protocol_handler {
       std::advance(iter, 2);
       if (!len) return true;
       if (len <= partial_parsed.end() - iter) {
-        std::advance(iter, len + 2);
-      }
+        std::advance(iter, len);
+	  } else {
+		return false;
+	  }
       begin = iter;
     }
     return false;

--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -391,7 +391,7 @@ struct http_async_protocol_handler {
     partial_parsed.append(part_begin, it);
     part_begin = part.begin();
     if (check_parse_body_complete()) {
-      callback(boost::asio::error::eof, bytes);
+      callback(boost::asio::error::eof, 0);
     } else {
       delegate_->read_some(
           boost::asio::mutable_buffers_1(part.data(), part.size()), callback);


### PR DESCRIPTION
I used the 0.13-release branch because we're updating an existing application to Visual Studio 2017 and it would build, and build against the latest boost 1.64.

At first, things didn't work at all. After using the simple_wget sample to debug it, I found that a bunch of the content (starting with the headers) had been appended after the BODY. I narrowed it down and fixed the new EOF callback when the server has sent a content-length header.

Next, Visual Studio's iterator debugging found the problem with the "len + 2" statement where it could go beyond the end of the string if the buffer didn't yet contain the crlf terminator after the current chunk. After fixing that, things mostly worked but I encountered an occasional infinite loop. From that state I figured out that the existing logic couldn't handle having a partial chunk in the buffer when checking if the chunks have all been received.

The new chunk handling code isn't overly efficient, but my changes got it to work reliably without any major changes to the partial buffer handling.
